### PR TITLE
fix: 修复无法打包构建，报 ts 的 png 类型错误提示的问题。

### DIFF
--- a/src/MyTestImagePack/index.tsx
+++ b/src/MyTestImagePack/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import './index.less';
+// @ts-ignore
 import light from './example-light.png';
 
 class TestImagePack extends React.Component {


### PR DESCRIPTION
close #11 
先前只在 typings.d.ts 中 declare module '*.png' 的方式不能完全消除错误提示